### PR TITLE
adds type and provider support for vxlan vtep flood addresses

### DIFF
--- a/lib/puppet/provider/eos_vxlan_vtep/default.rb
+++ b/lib/puppet/provider/eos_vxlan_vtep/default.rb
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2015, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+require 'puppet/type'
+require 'pathname'
+
+module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
+require File.join module_lib, 'puppet_x/eos/provider'
+
+Puppet::Type.type(:eos_vxlan_vtep).provide(:eos) do
+  # Create methods that set the @property_hash for the #flush method
+  mk_resource_methods
+
+  # Mix in the api as instance methods
+  include PuppetX::Eos::EapiProviderMixin
+
+  # Mix in the api as class methods
+  extend PuppetX::Eos::EapiProviderMixin
+
+  def self.instances
+    resources = node.api('interfaces').get('Vxlan1')
+    return [] unless resources
+    resources[:flood_list].map do |name|
+      provider_hash = { name: name, ensure: :present }
+      new(provider_hash)
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    node.api('interfaces').add_vtep('Vxlan1', resource[:name])
+    @property_hash = { name: resource[:name], ensure: :present }
+  end
+
+  def destroy
+    node.api('interfaces').remove_vtep('Vxlan1', resource[:name])
+    @property_hash = { name: resource[:name], ensure: :absent }
+  end
+end

--- a/lib/puppet/type/eos_vxlan_vtep.rb
+++ b/lib/puppet/type/eos_vxlan_vtep.rb
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2015, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#  Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  Neither the name of Arista Networks nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# encoding: utf-8
+
+Puppet::Type.newtype(:eos_vxlan_vtep) do
+  @doc = <<-EOS
+    This type provides management of the global Vxlan VTEP flood list.
+  EOS
+
+  ensurable
+
+  # Parameters
+
+  newparam(:name, namevar: true) do
+    desc <<-EOS
+      The name property associates the IPv4 flood address on the specified
+      VXLAN VNI interface.  The address value is configured using
+      address format.
+
+      For example
+
+        name => 192.168.10.16
+    EOS
+
+    validate do |value|
+      begin
+        IPAddr.new value
+      rescue ArgumentError => exc
+        fail "value #{value.inspect} is invalid, #{exc.message}"
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/eos_vxlan_vtep/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_vxlan_vtep/default_spec.rb
@@ -1,0 +1,140 @@
+#
+# Copyright (c) 2015, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+require 'spec_helper'
+
+include FixtureHelpers
+
+describe Puppet::Type.type(:eos_vxlan_vtep).provider(:eos) do
+  # Puppet RAL memoized methods
+  let(:resource) do
+    resource_hash = {
+      name: '1.1.1.1',
+      provider: described_class.name
+    }
+    Puppet::Type.type(:eos_vxlan_vtep).new(resource_hash)
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:api) { double('interfaces') }
+
+  def vxlan
+    vxlan = Fixtures[:vxlan]
+    return vxlan if vxlan
+    fixture('vxlan', dir: File.dirname(__FILE__))
+  end
+
+  before :each do
+    allow(described_class.node).to receive(:api).with('interfaces')
+      .and_return(api)
+
+    allow(provider.node).to receive(:api).with('interfaces').and_return(api)
+  end
+
+  context 'class methods' do
+    before { allow(api).to receive(:get).and_return(vxlan) }
+
+    describe '.instances' do
+      subject { described_class.instances }
+
+      it { is_expected.to be_an Array }
+
+      it 'has two entries' do
+        expect(subject.size).to eq(2)
+      end
+
+      it 'has an instance for 1.1.1.1' do
+        instance = subject.find { |p| p.name == '1.1.1.1' }
+        expect(instance).to be_a described_class
+      end
+
+      context 'eos_vxlan_vtep { 1.1.1.1: }' do
+        subject { described_class.instances.find { |p| p.name == '1.1.1.1' } }
+
+        include_examples 'provider resource methods',
+                         name: '1.1.1.1',
+                         ensure: :present
+      end
+    end
+
+    describe '.prefetch' do
+      let :resources do
+        {
+          '1.1.1.1' => Puppet::Type.type(:eos_vxlan_vtep).new(name: '1.1.1.1'),
+          '2.2.2.2' => Puppet::Type.type(:eos_vxlan_vtep).new(name: '2.2.2.2')
+        }
+      end
+      subject { described_class.prefetch(resources) }
+
+      it 'resource providers are absent prior to calling .prefetch' do
+        resources.values.each do |rsrc|
+          expect(rsrc.provider.exists?).to be_falsey
+        end
+      end
+
+      it 'sets the provider instance of the managed resource' do
+        subject
+        expect(resources['1.1.1.1'].provider.name).to eq '1.1.1.1'
+        expect(resources['1.1.1.1'].provider.exists?).to be_truthy
+      end
+
+      it 'does not set the provider instance of the unmanaged resource' do
+        subject
+        expect(resources['2.2.2.2'].provider.name).to eq '2.2.2.2'
+        expect(resources['2.2.2.2'].provider.exists?).to be_falsey
+      end
+    end
+  end
+
+  context 'resource (instance) methods' do
+    describe '#create' do
+      before do
+        expect(api).to receive(:add_vtep)
+          .with('Vxlan1', resource[:name])
+      end
+
+      it 'sets ensure to :present' do
+        provider.create
+        expect(provider.ensure).to eq(:present)
+      end
+    end
+
+    describe '#destroy' do
+      it 'sets ensure to :absent' do
+        resource[:ensure] = :absent
+        expect(api).to receive(:remove_vtep).with('Vxlan1', resource[:name])
+        provider.destroy
+        expect(provider.ensure).to eq(:absent)
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/eos_vxlan_vtep/fixture_vxlan.yaml
+++ b/spec/unit/puppet/provider/eos_vxlan_vtep/fixture_vxlan.yaml
@@ -1,0 +1,11 @@
+---
+:type: vxlan
+:description: test interface
+:shutdown: false
+:source_interface: Loopback0
+:multicast_group: 239.10.10.10
+:udp_port: 4789
+:flood_list: ['1.1.1.1', '3.3.3.3']
+:vlans:
+  '10':
+    :vni: '10'

--- a/spec/unit/puppet/type/eos_vxlan_vtep_spec.rb
+++ b/spec/unit/puppet/type/eos_vxlan_vtep_spec.rb
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2015, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#  Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  Neither the name of Arista Networks nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:eos_vxlan_vtep) do
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let(:type) { described_class.new(name: '1.1.1.1', catalog: catalog) }
+
+  it_behaves_like 'an ensurable type', name: '1.1.1.1'
+
+  describe 'name' do
+    let(:attribute) { :name }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'parameter'
+    include_examples '#doc Documentation'
+    include_examples 'accepts values without munging',
+                     %w(0.0.0.0 255.255.255.255)
+    include_examples 'rejects values', [[1], { two: :three }]
+  end
+end


### PR DESCRIPTION
This commit adds a new type eos_vxlan_vtep that can be used to manage
the global Vxlan VTEP flood list. Below is an example use:

eos_vxlan_vtep { '1.1.1.1':
   interface => Vxlan1
   ensure => present
}

eos_vxlan_vtep { '2.2.2.2':
   interface => Vxlan1
   ensure => present
}

The type is ensurable so vtep flood addresses can be added or removed.