### PR TITLE
Rubocop cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,12 @@ task :validate do
   end
 end
 
-desc "Generate Getting Started Guide HTML"
+desc 'Generate Getting Started Guide HTML'
 task :guide do
-    system "make -C guide html"
+  system 'make -C guide html'
 end
 
-desc "Clean Getting Started docs"
+desc 'Clean Getting Started docs'
 task :guide_clean do
-    system "make -C guide clean"
+  system 'make -C guide clean'
 end

--- a/lib/puppet/provider/eos_command/default.rb
+++ b/lib/puppet/provider/eos_command/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_command).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 
@@ -53,5 +52,4 @@ Puppet::Type.type(:eos_command).provide(:eos) do
     commands.insert(0, 'configure') if resource[:mode] == :config
     eapi.enable(commands)
   end
-
 end

--- a/lib/puppet/provider/eos_daemon/default.rb
+++ b/lib/puppet/provider/eos_daemon/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_daemon).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_eapi/default.rb
+++ b/lib/puppet/provider/eos_eapi/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_eapi).provide(:eos) do
-
   commands cli: 'FastCli'
 
   # Create methods that set the @property_hash for the #flush method

--- a/lib/puppet/provider/eos_extension/default.rb
+++ b/lib/puppet/provider/eos_extension/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_extension).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_logging_host/default.rb
+++ b/lib/puppet/provider/eos_logging_host/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_logging_host).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_mst_instance/default.rb
+++ b/lib/puppet/provider/eos_mst_instance/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_mst_instance).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_ospf_instance/default.rb
+++ b/lib/puppet/provider/eos_ospf_instance/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_ospf_instance).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_ospf_interface/default.rb
+++ b/lib/puppet/provider/eos_ospf_interface/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_ospf_interface).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_static_route/default.rb
+++ b/lib/puppet/provider/eos_static_route/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_static_route).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_stp_config/default.rb
+++ b/lib/puppet/provider/eos_stp_config/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_stp_config).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_stp_interface/default.rb
+++ b/lib/puppet/provider/eos_stp_interface/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_stp_interface).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_varp/default.rb
+++ b/lib/puppet/provider/eos_varp/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_varp).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 

--- a/lib/puppet/provider/eos_varp_interface/default.rb
+++ b/lib/puppet/provider/eos_varp_interface/default.rb
@@ -33,7 +33,6 @@ require 'puppet/type'
 require 'puppet_x/eos/provider'
 
 Puppet::Type.type(:eos_varp_interface).provide(:eos) do
-
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 
@@ -49,7 +48,7 @@ Puppet::Type.type(:eos_varp_interface).provide(:eos) do
       provider_hash = { name: name, ensure: :present }
       provider_hash[:addresses] = attrs['addresses']
       arry << new(provider_hash)
-      end
+    end
   end
 
   def addresses=(val)

--- a/lib/puppet/type/eos_access_list.rb
+++ b/lib/puppet/type/eos_access_list.rb
@@ -67,5 +67,4 @@ Puppet::Type.newtype(:eos_access_list) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_command.rb
+++ b/lib/puppet/type/eos_command.rb
@@ -59,5 +59,4 @@ Puppet::Type.newtype(:eos_command) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_daemon.rb
+++ b/lib/puppet/type/eos_daemon.rb
@@ -56,5 +56,4 @@ Puppet::Type.newtype(:eos_daemon) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_eapi.rb
+++ b/lib/puppet/type/eos_eapi.rb
@@ -72,5 +72,4 @@ Puppet::Type.newtype(:eos_eapi) do
     desc 'Enable or disable EAPI for the specified protocol.'
     newvalues(:true, :false)
   end
-
 end

--- a/lib/puppet/type/eos_extension.rb
+++ b/lib/puppet/type/eos_extension.rb
@@ -66,5 +66,4 @@ Puppet::Type.newtype(:eos_extension) do
     desc 'Uses the force keyword when installing extensions'
     newvalues(:true, :false)
   end
-
 end

--- a/lib/puppet/type/eos_lacp_interface.rb
+++ b/lib/puppet/type/eos_lacp_interface.rb
@@ -60,5 +60,4 @@ Puppet::Type.newtype(:eos_lacp_interface) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_logging_host.rb
+++ b/lib/puppet/type/eos_logging_host.rb
@@ -43,7 +43,5 @@ Puppet::Type.newtype(:eos_logging_host) do
     desc 'The resource name for the logging host should be the hostname in
       either IP format or FQDN format of the destination host.'
   end
-
   # Properties (state management)
-
 end

--- a/lib/puppet/type/eos_mst_instance.rb
+++ b/lib/puppet/type/eos_mst_instance.rb
@@ -69,5 +69,4 @@ Puppet::Type.newtype(:eos_mst_instance) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_ospf_area.rb
+++ b/lib/puppet/type/eos_ospf_area.rb
@@ -56,5 +56,4 @@ Puppet::Type.newtype(:eos_ospf_area) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_ospf_interface.rb
+++ b/lib/puppet/type/eos_ospf_interface.rb
@@ -54,5 +54,4 @@ Puppet::Type.newtype(:eos_ospf_interface) do
     desc 'Specifies the network type'
     newvalues(:point_to_point, :broadcast)
   end
-
 end

--- a/lib/puppet/type/eos_prefixlist.rb
+++ b/lib/puppet/type/eos_prefixlist.rb
@@ -62,5 +62,4 @@ Puppet::Type.newtype(:eos_prefixlist) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_staticroute.rb
+++ b/lib/puppet/type/eos_staticroute.rb
@@ -62,5 +62,4 @@ Puppet::Type.newtype(:eos_staticroute) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/eos_stp_config.rb
+++ b/lib/puppet/type/eos_stp_config.rb
@@ -46,5 +46,4 @@ Puppet::Type.newtype(:eos_stp_config) do
     desc 'Specifies STP mode of operation'
     newvalues(:mstp, :none)
   end
-
 end

--- a/lib/puppet/type/eos_user.rb
+++ b/lib/puppet/type/eos_user.rb
@@ -66,5 +66,4 @@ Puppet::Type.newtype(:eos_user) do
     desc 'When to update the password'
     newvalues(:always, :on_create)
   end
-
 end

--- a/spec/unit/puppet/provider/eos_daemon_spec.rb
+++ b/spec/unit/puppet/provider/eos_daemon_spec.rb
@@ -32,7 +32,6 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:eos_daemon).provider(:eos) do
-
   # Puppet RAL memoized methods
   let(:resource) do
     resource_hash = {
@@ -67,7 +66,6 @@ describe Puppet::Type.type(:eos_daemon).provider(:eos) do
   end
 
   context 'class methods' do
-
     describe '.instances' do
       subject { described_class.instances }
 

--- a/spec/unit/puppet/provider/eos_extension_spec.rb
+++ b/spec/unit/puppet/provider/eos_extension_spec.rb
@@ -32,7 +32,6 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:eos_extension).provider(:eos) do
-
   # Puppet RAL memoized methods
   let(:resource) do
     resource_hash = {
@@ -65,7 +64,6 @@ describe Puppet::Type.type(:eos_extension).provider(:eos) do
   end
 
   context 'class methods' do
-
     describe '.instances' do
       subject { described_class.instances }
 

--- a/spec/unit/puppet/provider/eos_logging_host/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_logging_host/default_spec.rb
@@ -34,7 +34,6 @@ require 'spec_helper'
 include FixtureHelpers
 
 describe Puppet::Type.type(:eos_logging_host).provider(:eos) do
-
   # Puppet RAL memoized methods
   let(:resource) do
     resource_hash = {
@@ -60,7 +59,6 @@ describe Puppet::Type.type(:eos_logging_host).provider(:eos) do
   end
 
   context 'class methods' do
-
     before { allow(api).to receive(:get).and_return(logging) }
 
     describe '.instances' do
@@ -89,8 +87,10 @@ describe Puppet::Type.type(:eos_logging_host).provider(:eos) do
     describe '.prefetch' do
       let :resources do
         {
-          '1.2.3.4' => Puppet::Type.type(:eos_logging_host) .new(name: '1.2.3.4'),
-          '5.6.7.8' => Puppet::Type.type(:eos_logging_host) .new(name: '5.6.7.8')
+          '1.2.3.4' => Puppet::Type.type(:eos_logging_host)
+            .new(name: '1.2.3.4'),
+          '5.6.7.8' => Puppet::Type.type(:eos_logging_host)
+            .new(name: '5.6.7.8')
         }
       end
       subject { described_class.prefetch(resources) }
@@ -116,7 +116,6 @@ describe Puppet::Type.type(:eos_logging_host).provider(:eos) do
   end
 
   context 'resource (instance) methods' do
-
     describe '#exists?' do
       subject { provider.exists? }
 

--- a/spec/unit/puppet/provider/eos_ospf_instance_spec.rb
+++ b/spec/unit/puppet/provider/eos_ospf_instance_spec.rb
@@ -32,7 +32,6 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:eos_ospf_instance).provider(:eos) do
-
   # Puppet RAL memoized methods
   let(:resource) do
     resource_hash = {
@@ -61,7 +60,6 @@ describe Puppet::Type.type(:eos_ospf_instance).provider(:eos) do
   end
 
   context 'class methods' do
-
     before { allow(api).to receive(:getall).and_return(ospf) }
 
     describe '.instances' do
@@ -86,7 +84,6 @@ describe Puppet::Type.type(:eos_ospf_instance).provider(:eos) do
                          name: '1',
                          router_id: '1.1.1.1'
       end
-
     end
 
     describe '.prefetch' do
@@ -122,7 +119,6 @@ describe Puppet::Type.type(:eos_ospf_instance).provider(:eos) do
   end
 
   context 'resource (instance) methods' do
-
     describe '#exists?' do
       subject { provider.exists? }
 
@@ -140,11 +136,10 @@ describe Puppet::Type.type(:eos_ospf_instance).provider(:eos) do
     end
 
     describe '#create' do
-
       before :each do
         expect(api).to receive(:create).with(resource[:name])
         allow(api).to receive_messages(
-          :set_router_id => true
+          set_router_id: true
         )
       end
 
@@ -164,7 +159,7 @@ describe Puppet::Type.type(:eos_ospf_instance).provider(:eos) do
         expect(api).to receive(:delete).with(resource[:name])
         provider.destroy
         expect(provider.ensure).to eq(:absent)
-        end
+      end
     end
 
     describe '#router_id=(val)' do

--- a/spec/unit/puppet/provider/eos_ospf_interface_spec.rb
+++ b/spec/unit/puppet/provider/eos_ospf_interface_spec.rb
@@ -32,7 +32,6 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
-
   # Puppet RAL memoized methods
   let(:resource) do
     resource_hash = {
@@ -63,7 +62,6 @@ describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
   end
 
   context 'class methods' do
-
     before { allow(api).to receive(:get).and_return(ospf) }
 
     describe '.instances' do
@@ -88,14 +86,15 @@ describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
                          name: 'Ethernet1',
                          network_type: :point_to_point
       end
-
     end
 
     describe '.prefetch' do
       let :resources do
         {
-          'Ethernet1' => Puppet::Type.type(:eos_ospf_interface).new(name: 'Ethernet1'),
-          'Ethernet2' => Puppet::Type.type(:eos_ospf_interface).new(name: 'Ethernet2')
+          'Ethernet1' => Puppet::Type.type(:eos_ospf_interface)
+            .new(name: 'Ethernet1'),
+          'Ethernet2' => Puppet::Type.type(:eos_ospf_interface)
+            .new(name: 'Ethernet2')
         }
       end
 
@@ -111,7 +110,8 @@ describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
         subject
         expect(resources['Ethernet1'].provider.name).to eq 'Ethernet1'
         expect(resources['Ethernet1'].provider.exists?).to be_truthy
-        expect(resources['Ethernet1'].provider.network_type).to eq :point_to_point
+        expect(resources['Ethernet1'].provider.network_type)
+          .to eq :point_to_point
       end
 
       it 'does not set the provider instance of the unmanaged resource' do
@@ -124,7 +124,6 @@ describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
   end
 
   context 'resource (instance) methods' do
-
     describe '#exists?' do
       subject { provider.exists? }
 
@@ -142,11 +141,10 @@ describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
     end
 
     describe '#create' do
-
       before :each do
         expect(interfaces).to receive(:create).with(resource[:name])
         allow(interfaces).to receive_messages(
-          :set_network_type => true
+          set_network_type: true
         )
       end
 
@@ -166,7 +164,7 @@ describe Puppet::Type.type(:eos_ospf_interface).provider(:eos) do
         expect(interfaces).to receive(:delete).with(resource[:name])
         provider.destroy
         expect(provider.ensure).to eq(:absent)
-        end
+      end
     end
 
     describe '#network_type=(val)' do

--- a/spec/unit/puppet/provider/eos_varp_interface_spec.rb
+++ b/spec/unit/puppet/provider/eos_varp_interface_spec.rb
@@ -32,7 +32,6 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
-
   # Puppet RAL memoized methods
   let(:resource) do
     resource_hash = {
@@ -63,7 +62,6 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
   end
 
   context 'class methods' do
-
     before { allow(api).to receive(:get).and_return(varp) }
 
     describe '.instances' do
@@ -75,7 +73,7 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
         expect(subject.size).to eq 1
       end
 
-      it "has an instance for interface Vlan1234" do
+      it 'has an instance for interface Vlan1234' do
         instance = subject.find { |p| p.name == 'Vlan1234' }
         expect(instance).to be_a described_class
       end
@@ -93,7 +91,8 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
     describe '.prefetch' do
       let :resources do
         {
-          'Vlan1234' => Puppet::Type.type(:eos_varp_interface).new(name: 'Vlan1234'),
+          'Vlan1234' => Puppet::Type.type(:eos_varp_interface)
+            .new(name: 'Vlan1234'),
           'Vlan1' => Puppet::Type.type(:eos_varp_interface).new(name: 'Vlan1')
         }
       end
@@ -110,7 +109,8 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
         subject
         expect(resources['Vlan1234'].provider.name).to eq('Vlan1234')
         expect(resources['Vlan1234'].provider.exists?).to be_truthy
-        expect(resources['Vlan1234'].provider.addresses).to eq(['1.1.1.1', '2.2.2.2'])
+        expect(resources['Vlan1234'].provider.addresses)
+          .to eq(['1.1.1.1', '2.2.2.2'])
       end
 
       it 'does not set the provider instance of the unmanaged resource' do
@@ -123,7 +123,6 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
   end
 
   context 'resource (instance) methods' do
-
     describe '#exists?' do
       subject { provider.exists? }
 
@@ -141,11 +140,10 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
     end
 
     describe '#create' do
-
       before :each do
         expect(interfaces).to receive(:create).with(resource[:name])
         allow(interfaces).to receive_messages(
-          :set_addresses => true
+          set_addresses: true
         )
       end
 
@@ -173,7 +171,8 @@ describe Puppet::Type.type(:eos_varp_interface).provider(:eos) do
       let(:addresses) { %w(1.1.1.1 2.2.2.2) }
 
       it 'updates addresses in the provider' do
-        expect(interfaces).to receive(:set_addresses).with(name, value: addresses)
+        expect(interfaces).to receive(:set_addresses)
+          .with(name, value: addresses)
         provider.addresses = addresses
         expect(provider.addresses).to eq addresses
       end

--- a/spec/unit/puppet/provider/eos_varp_spec.rb
+++ b/spec/unit/puppet/provider/eos_varp_spec.rb
@@ -32,7 +32,6 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:eos_varp).provider(:eos) do
-
   let :resource do
     resource_hash = {
       name: 'settings',
@@ -58,7 +57,6 @@ describe Puppet::Type.type(:eos_varp).provider(:eos) do
   end
 
   context 'class methods' do
-
     before { allow(api).to receive(:get).and_return(varp) }
 
     describe '.instances' do
@@ -106,7 +104,8 @@ describe Puppet::Type.type(:eos_varp).provider(:eos) do
         subject
         expect(resources['settings'].provider.name).to eq 'settings'
         expect(resources['settings'].provider.exists?).to be_truthy
-        expect(resources['settings'].provider.mac_address).to eq 'aa:bb:cc:dd:ee:ff'
+        expect(resources['settings'].provider.mac_address)
+          .to eq 'aa:bb:cc:dd:ee:ff'
       end
 
       it 'does not set the provider instance of the unmanged resource' do
@@ -119,7 +118,6 @@ describe Puppet::Type.type(:eos_varp).provider(:eos) do
   end
 
   context 'resource (instance) methods' do
-
     describe '#exists?' do
       subject { provider.exists? }
 
@@ -138,7 +136,8 @@ describe Puppet::Type.type(:eos_varp).provider(:eos) do
 
     describe '#mac_address=(value)' do
       it 'updates mac_address with value "11:22:33:44:55:66"' do
-        expect(api).to receive(:set_mac_address).with(value: '11:22:33:44:55:66')
+        expect(api).to receive(:set_mac_address)
+          .with(value: '11:22:33:44:55:66')
         provider.mac_address = '11:22:33:44:55:66'
         expect(provider.mac_address).to eq('11:22:33:44:55:66')
       end

--- a/spec/unit/puppet/type/eos_access_list_spec.rb
+++ b/spec/unit/puppet/type/eos_access_list_spec.rb
@@ -67,5 +67,4 @@ describe Puppet::Type.type(:eos_access_list) do
     include_examples '#doc Documentation'
     include_examples 'array of strings value'
   end
-
 end

--- a/spec/unit/puppet/type/eos_command_spec.rb
+++ b/spec/unit/puppet/type/eos_command_spec.rb
@@ -64,5 +64,4 @@ describe Puppet::Type.type(:eos_command) do
     include_examples 'array of strings value'
     include_examples 'rejects values', [0, [1], { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_daemon_spec.rb
+++ b/spec/unit/puppet/type/eos_daemon_spec.rb
@@ -56,5 +56,4 @@ describe Puppet::Type.type(:eos_daemon) do
     include_examples 'accepts values without munging', %w(/etc/rsyslogd)
     include_examples 'rejects values', [[1], { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_eapi_spec.rb
+++ b/spec/unit/puppet/type/eos_eapi_spec.rb
@@ -74,5 +74,4 @@ describe Puppet::Type.type(:eos_eapi) do
     include_examples 'boolean value'
     include_examples 'rejected parameter values'
   end
-
 end

--- a/spec/unit/puppet/type/eos_extension_spec.rb
+++ b/spec/unit/puppet/type/eos_extension_spec.rb
@@ -76,5 +76,4 @@ describe Puppet::Type.type(:eos_extension) do
     include_examples 'boolean value'
     include_examples 'rejected parameter values'
   end
-
 end

--- a/spec/unit/puppet/type/eos_lacp_interface_spec.rb
+++ b/spec/unit/puppet/type/eos_lacp_interface_spec.rb
@@ -66,5 +66,4 @@ describe Puppet::Type.type(:eos_lacp_interface) do
     include_examples 'numeric parameter', min: 0, max: 65_535
     include_examples 'rejected parameter values'
   end
-
 end

--- a/spec/unit/puppet/type/eos_logging_host_spec.rb
+++ b/spec/unit/puppet/type/eos_logging_host_spec.rb
@@ -46,5 +46,4 @@ describe Puppet::Type.type(:eos_logging_host) do
     include_examples 'parameter'
     include_examples '#doc Documentation'
   end
-
 end

--- a/spec/unit/puppet/type/eos_mst_instance_spec.rb
+++ b/spec/unit/puppet/type/eos_mst_instance_spec.rb
@@ -58,5 +58,4 @@ describe Puppet::Type.type(:eos_mst_instance) do
     include_examples 'accepts values without munging', %w(0 20480 45056 61440)
     include_examples 'rejects values', [100, 65_536, 'string', { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_ospf_area_spec.rb
+++ b/spec/unit/puppet/type/eos_ospf_area_spec.rb
@@ -56,5 +56,4 @@ describe Puppet::Type.type(:eos_ospf_area) do
     include_examples 'array of strings value'
     include_examples 'rejects values', [0, [1], { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_ospf_instance_spec.rb
+++ b/spec/unit/puppet/type/eos_ospf_instance_spec.rb
@@ -57,5 +57,4 @@ describe Puppet::Type.type(:eos_ospf_instance) do
                      %w(0.0.0.0 255.255.255.255)
     include_examples 'rejects values', [[1], { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_ospf_interface_spec.rb
+++ b/spec/unit/puppet/type/eos_ospf_interface_spec.rb
@@ -58,5 +58,4 @@ describe Puppet::Type.type(:eos_ospf_interface) do
     include_examples 'accepts values', [:point_to_point, :broadcast]
     include_examples 'rejected parameter values'
   end
-
 end

--- a/spec/unit/puppet/type/eos_prefixlist_spec.rb
+++ b/spec/unit/puppet/type/eos_prefixlist_spec.rb
@@ -57,5 +57,4 @@ describe Puppet::Type.type(:eos_prefixlist) do
     include_examples '#doc Documentation'
     include_examples 'array of strings value'
   end
-
 end

--- a/spec/unit/puppet/type/eos_staticroute_spec.rb
+++ b/spec/unit/puppet/type/eos_staticroute_spec.rb
@@ -59,5 +59,4 @@ describe Puppet::Type.type(:eos_staticroute) do
     include_examples 'accepts values without munging', %w(Server Room)
     include_examples 'rejects values', [[1], { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_stp_config_spec.rb
+++ b/spec/unit/puppet/type/eos_stp_config_spec.rb
@@ -54,5 +54,4 @@ describe Puppet::Type.type(:eos_stp_config) do
     include_examples 'accepts values', [:mstp, :none]
     include_examples 'rejected parameter values'
   end
-
 end

--- a/spec/unit/puppet/type/eos_user_spec.rb
+++ b/spec/unit/puppet/type/eos_user_spec.rb
@@ -77,5 +77,4 @@ describe Puppet::Type.type(:eos_user) do
     include_examples 'accepts values', [:always, :on_create]
     include_examples 'rejected parameter values'
   end
-
 end

--- a/spec/unit/puppet/type/eos_varp_spec.rb
+++ b/spec/unit/puppet/type/eos_varp_spec.rb
@@ -54,5 +54,4 @@ describe Puppet::Type.type(:eos_varp) do
     include_examples 'accepts values without munging', %w(001c.7300.0099)
     include_examples 'rejects values', [[1], { two: :three }]
   end
-
 end

--- a/spec/unit/puppet/type/eos_vrrp_spec.rb
+++ b/spec/unit/puppet/type/eos_vrrp_spec.rb
@@ -54,5 +54,4 @@ describe Puppet::Type.type(:eos_vrrp) do
     include_examples 'accepts values without munging', %w(001c.7300.0099)
     include_examples 'rejects values', [[1], { two: :three }]
   end
-
 end


### PR DESCRIPTION
Some unit tests are still failing but they are for types/providers that have not been officially released.
There is still one Rubocop issue but it is on provider/eos_ospf_instance/default.rb which has not been officially released.