### PR TITLE
Addressed Rubocop issues

### DIFF
--- a/lib/puppet/provider/eos_bgp_config/default.rb
+++ b/lib/puppet/provider/eos_bgp_config/default.rb
@@ -112,9 +112,10 @@ Puppet::Type.type(:eos_bgp_config).provide(:eos) do
       if maximum_ecmp_paths && desired_maximum
         @property_flush[:maximum_paths] = @property_hash[:maximum_paths]
       end
-      @property_flush.delete(:provider)
-      @property_flush.delete(:ensure)
-      @property_flush.delete(:loglevel)
+      remove_puppet_keys(@property_flush)
+      # @property_flush.delete(:provider)
+      # @property_flush.delete(:ensure)
+      # @property_flush.delete(:loglevel)
       api.create(resource[:name], @property_flush)
     when :absent
       api.delete

--- a/lib/puppet/provider/eos_bgp_config/default.rb
+++ b/lib/puppet/provider/eos_bgp_config/default.rb
@@ -113,9 +113,6 @@ Puppet::Type.type(:eos_bgp_config).provide(:eos) do
         @property_flush[:maximum_paths] = @property_hash[:maximum_paths]
       end
       remove_puppet_keys(@property_flush)
-      # @property_flush.delete(:provider)
-      # @property_flush.delete(:ensure)
-      # @property_flush.delete(:loglevel)
       api.create(resource[:name], @property_flush)
     when :absent
       api.delete

--- a/lib/puppet/provider/eos_user/default.rb
+++ b/lib/puppet/provider/eos_user/default.rb
@@ -116,9 +116,7 @@ Puppet::Type.type(:eos_user).provide(:eos) do
       else
         @property_flush[:secret] = @property_hash[:secret]
       end
-      @property_flush.delete(:provider)
-      @property_flush.delete(:ensure)
-      @property_flush.delete(:loglevel)
+      remove_puppet_keys(@property_flush)
       api.create(resource[:name], @property_flush)
     when :absent
       api.delete(resource[:name])

--- a/lib/puppet_x/eos/provider.rb
+++ b/lib/puppet_x/eos/provider.rb
@@ -81,6 +81,22 @@ module PuppetX
         fail Puppet::Error, msg if errors
       end
       private :validate
+
+      ##
+      # remove_puppet_keys deletes the :provider, :ensure, :loglevel keys
+      # from the passed in hash. This allows the provider to pass in
+      # property_flush to the rbeapi calls without having key:value pairs
+      # in the hash that are not required for the rbeapi call.
+      #
+      # @api private
+      #
+      # @param [Hash] :property_flush The providers property_flush hash.
+      def remove_puppet_keys(property_flush)
+        property_flush.delete(:provider)
+        property_flush.delete(:ensure)
+        property_flush.delete(:loglevel)
+      end
+      private :remove_puppet_keys
     end
   end
 end

--- a/spec/unit/puppet/provider/eos_user/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_user/default_spec.rb
@@ -34,6 +34,7 @@ require 'spec_helper'
 include FixtureHelpers
 
 describe Puppet::Type.type(:eos_user).provider(:eos) do
+  # rubocop:disable Metrics/MethodLength
   def load_default_settings
     @name = 'Username'
     @nopassword = :false


### PR DESCRIPTION
Added provider library method to delete the puppet specific keys
from the property_flush hash before passing in the hash to the
rbeapi library.