### PR TITLE
Fixed Typo in the vlan provider in the trunk_groups function.

### DIFF
--- a/lib/puppet/provider/eos_vlan/default.rb
+++ b/lib/puppet/provider/eos_vlan/default.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:eos_vlan).provide(:eos) do
   end
 
   def trunk_groups=(value)
-    node.api('vlans').set_trunk_groups(resource[:vlanid], value: value)
+    node.api('vlans').add_trunk_group(resource[:vlanid], value: value)
     @property_hash[:trunk_groups] = value
   end
 


### PR DESCRIPTION
I want to configure a trunk_group with the follwing puppet code.
 eos_vlan { '4094':
    enable       => true,
    vlan_name    => 'MLAG_control',
    trunk_groups => ['trunkpeer'],
  }
I will get this error:

Error: Could not set 'present' on ensure: undefined method `set_trunk_groups' for #<Rbeapi::Api::Vlans:0x8dcc1e0> at 102:/etc/puppetlabs/code/environments/production/manifests/init.pp
Error: Could not set 'present' on ensure: undefined method `set_trunk_groups' for #<Rbeapi::Api::Vlans:0x8dcc1e0> at 102:/etc/puppetlabs/code/environments/production/manifests/init.pp
Wrapped exception:
undefined method `set_trunk_groups' for #<Rbeapi::Api::Vlans:0x8dcc1e0>
Error: /Stage[main]/Strato/Eos_vlan[4094]/ensure: change from absent to present failed: Could not set 'present' on ensure: undefined method `set_trunk_groups' for #<Rbeapi::Api::Vlans:0x8dcc1e0> at 102:/etc/puppetlabs/code/environments/production/manifests/init.pp

This patch is fixing the typo.

Afterwards the puppet run is without an error.