### PR TITLE
Back out change from PR 78 - use set_trunk_groups.

### DIFF
--- a/lib/puppet/provider/eos_vlan/default.rb
+++ b/lib/puppet/provider/eos_vlan/default.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:eos_vlan).provide(:eos) do
   end
 
   def trunk_groups=(value)
-    node.api('vlans').add_trunk_group(resource[:vlanid], value: value)
+    node.api('vlans').set_trunk_groups(resource[:vlanid], value: value)
     @property_hash[:trunk_groups] = value
   end
 

--- a/lib/puppet/provider/eos_vrrp/default.rb
+++ b/lib/puppet/provider/eos_vrrp/default.rb
@@ -51,7 +51,6 @@ Puppet::Type.type(:eos_vrrp).provide(:eos) do
   extend PuppetX::Eos::EapiProviderMixin
 
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def self.instances
     entries = node.api('vrrp').getall
     return [] if !entries || entries.empty?


### PR DESCRIPTION
Clean up rubocop issue in eos_vrrp.