### PR TITLE
Fix issue with autoload of helper

### DIFF
--- a/lib/puppet/type/eos_acl_entry.rb
+++ b/lib/puppet/type/eos_acl_entry.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_acl_entry) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_bgp_config.rb
+++ b/lib/puppet/type/eos_bgp_config.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_bgp_config) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_bgp_neighbor.rb
+++ b/lib/puppet/type/eos_bgp_neighbor.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_bgp_neighbor) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_bgp_network.rb
+++ b/lib/puppet/type/eos_bgp_network.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_bgp_network) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_config.rb
+++ b/lib/puppet/type/eos_config.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_config) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_ipinterface.rb
+++ b/lib/puppet/type/eos_ipinterface.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_ipinterface) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_mlag.rb
+++ b/lib/puppet/type/eos_mlag.rb
@@ -31,7 +31,8 @@
 #
 # encoding: utf-8
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_mlag) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_routemap.rb
+++ b/lib/puppet/type/eos_routemap.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_routemap) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_staticroute.rb
+++ b/lib/puppet/type/eos_staticroute.rb
@@ -31,7 +31,8 @@
 #
 # encoding: utf-8
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_staticroute) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_user.rb
+++ b/lib/puppet/type/eos_user.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_user) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_varp.rb
+++ b/lib/puppet/type/eos_varp.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 require 'netaddr'
 
 Puppet::Type.newtype(:eos_varp) do

--- a/lib/puppet/type/eos_varp_interface.rb
+++ b/lib/puppet/type/eos_varp_interface.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_varp_interface) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_vrrp.rb
+++ b/lib/puppet/type/eos_vrrp.rb
@@ -30,7 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_vrrp) do
   @doc = <<-EOS

--- a/lib/puppet/type/eos_vxlan.rb
+++ b/lib/puppet/type/eos_vxlan.rb
@@ -31,7 +31,8 @@
 #
 # encoding: utf-8
 
-require 'puppet_x/eos/utils/helpers'
+# Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
+require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
 
 Puppet::Type.newtype(:eos_vxlan) do
   @doc = <<-EOS


### PR DESCRIPTION
In certain situations the require 'puppet_x/eos/utils/helpers' line results in an error like this: Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, Could not autoload puppet/type/eos_user: no such file to load -- puppet_x/eos/utils/helpers at /etc/puppetlabs/code/environments/production/modules/nc_arista_eos/manifests/init.pp:72:3 on node tor1.localdomain
The implemented workaround fixes this.