### PR TITLE
implemented trunk group support for the eos_switchport provider

### DIFF
--- a/lib/puppet/provider/eos_switchport/default.rb
+++ b/lib/puppet/provider/eos_switchport/default.rb
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2014, Arista Networks, Inc.
 # All rights reserved.
 #
@@ -60,6 +59,11 @@ Puppet::Type.type(:eos_switchport).provide(:eos) do
     end
   end
 
+  def trunk_groups=(val)
+    node.api('switchports').set_trunk_groups(resource[:name], value: val)
+    @property_hash[:trunk_groups] = val
+  end
+
   def mode=(val)
     node.api('switchports').set_mode(resource[:name], value: val)
     @property_hash[:mode] = val
@@ -87,6 +91,9 @@ Puppet::Type.type(:eos_switchport).provide(:eos) do
   def create
     node.api('switchports').create(resource[:name])
     @property_hash = { name: resource[:name], ensure: :present }
+    self.trunk_groups= resource[:trunk_groups] \
+                               if resource[:trunk_groups]
+
     self.mode = resource[:mode] if resource[:mode]
 
     self.trunk_allowed_vlans = resource[:trunk_allowed_vlans] \

--- a/lib/puppet/type/eos_switchport.rb
+++ b/lib/puppet/type/eos_switchport.rb
@@ -49,6 +49,7 @@ Puppet::Type.newtype(:eos_switchport) do
           mode                => trunk,
           trunk_allowed_vlans => [1, 100, 101, 102, 103, 104],
           trunk_native_vlan   => 10,
+          trunk_groups        => [tg1, tg2],
         }
   EOS
 
@@ -75,6 +76,33 @@ Puppet::Type.newtype(:eos_switchport) do
   end
 
   # Properties (state management)
+
+  newproperty(:trunk_groups, array_matching: :all) do
+    desc <<-EOS
+      The trunk_groups property assigns an array of trunk group names to
+      the specified switchport/portchannel. A trunk group is the set of
+      interfaces that comprise the trunk and the collection of VLANs whose traffic
+      is carried only on ports that are members of the trunk groups to which
+      the VLAN belongs.
+
+      Example configuration
+
+      trunk_groups => ['tg1', 'tg2']
+
+      The default configure is an empty list
+    EOS
+
+    # Sort the arrays before comparing
+    def insync?(current)
+      current.sort == should.sort
+    end
+
+    validate do |value|
+      unless value.is_a? String
+        fail "value #{value.inspect} is not a String"
+      end
+    end
+  end
 
   newproperty(:mode) do
     desc <<-EOS

--- a/spec/unit/puppet/provider/eos_switchport/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_switchport/default_spec.rb
@@ -43,6 +43,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
       trunk_allowed_vlans: %w(1 10 100 1000),
       trunk_native_vlan: '1',
       access_vlan: '1',
+      trunk_groups: [],
       provider: described_class.name
     }
     Puppet::Type.type(:eos_switchport).new(resource_hash)
@@ -92,7 +93,8 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
                          mode: :trunk,
                          trunk_allowed_vlans: [1, 10, 100, 1000],
                          trunk_native_vlan: '1',
-                         access_vlan: '1'
+                         access_vlan: '1',
+                         trunk_groups: []
       end
     end
 
@@ -114,6 +116,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
           expect(rsrc.provider.trunk_native_vlan).to eq(:absent)
           expect(rsrc.provider.access_vlan).to eq(:absent)
           expect(rsrc.provider.trunk_allowed_vlans).to eq(:absent)
+          expect(rsrc.provider.trunk_groups).to eq(:absent)
         end
       end
 
@@ -126,6 +129,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
         expect(resources['Ethernet1'].provider.trunk_native_vlan).to eq '1'
         expect(resources['Ethernet1'].provider.trunk_allowed_vlans).to \
           eq [1, 10, 100, 1000]
+        expect(resources['Ethernet1'].provider.trunk_groups).to eq []
       end
 
       it 'does not set the provider instance of the unmanaged resource' do
@@ -137,6 +141,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
         expect(resources['Ethernet2'].provider.trunk_native_vlan).to eq :absent
         expect(resources['Ethernet2'].provider.trunk_allowed_vlans).to \
           eq :absent
+        expect(resources['Ethernet2'].provider.trunk_groups).to eq :absent
       end
     end
   end
@@ -167,7 +172,8 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
           set_mode: true,
           set_access_vlan: true,
           set_trunk_native_vlan: true,
-          set_trunk_allowed_vlans: true
+          set_trunk_allowed_vlans: true,
+          set_trunk_groups: true
         )
       end
 
@@ -195,6 +201,11 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
       it 'sets access_vlan to the resource value' do
         provider.create
         expect(provider.access_vlan).to eq resource[:access_vlan]
+      end
+
+      it 'sets trunk_groups to the resource value array' do
+        provider.create
+        expect(provider.trunk_groups).to eq(provider.resource[:trunk_groups])
       end
     end
 
@@ -244,6 +255,17 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
           .with(resource[:name], value: 1000)
         provider.access_vlan = 1000
         expect(provider.access_vlan).to eq(1000)
+      end
+    end
+
+    describe '#trunk_groups=(value)' do
+      let(:vid) { resource[:name] }
+      let(:tgs) { %w(tg1 tg2 tg3) }
+
+      it 'updates trunk_groups with array [tg1, tg2, tg3]' do
+        expect(api).to receive(:set_trunk_groups).with(vid, value: tgs)
+        provider.trunk_groups = tgs
+        expect(provider.trunk_groups).to eq(tgs)
       end
     end
   end

--- a/spec/unit/puppet/provider/eos_switchport/fixture_switchports.yaml
+++ b/spec/unit/puppet/provider/eos_switchport/fixture_switchports.yaml
@@ -4,4 +4,5 @@ Ethernet1:
   :access_vlan: "1"
   :trunk_native_vlan: "1"
   :trunk_allowed_vlans: [1,10,100,1000]
+  :trunk_groups: []
 

--- a/spec/unit/puppet/type/eos_switchport_spec.rb
+++ b/spec/unit/puppet/type/eos_switchport_spec.rb
@@ -85,4 +85,13 @@ describe Puppet::Type.type(:eos_switchport) do
     include_examples '#doc Documentation'
     include_examples 'vlan id value'
   end
+
+  describe 'trunk_groups' do
+    let(:attribute) { :trunk_groups }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'property'
+    include_examples '#doc Documentation'
+    include_examples 'accepts values without munging', [%w(tg1 tg2)]
+  end
 end


### PR DESCRIPTION
This patch implemented trunk groups support for the eos_switchport provider.
Now trunk groups could be set on switchports and portchannel interfaces.
Together with the support of trunk groups in the eos_vlan provider the trunk    groups support is now complete.

Please verify, test and if possible merge.

Thanks alot.
