### PR TITLE
add ethernet speed and lacp port priority support

### DIFF
--- a/lib/puppet/provider/eos_ethernet/default.rb
+++ b/lib/puppet/provider/eos_ethernet/default.rb
@@ -59,6 +59,7 @@ Puppet::Type.type(:eos_ethernet).provide(:eos) do
       provider_hash[:description] = attrs[:description]
       provider_hash[:flowcontrol_send] = attrs[:flowcontrol_send].to_sym
       provider_hash[:flowcontrol_receive] = attrs[:flowcontrol_receive].to_sym
+      provider_hash[:speed] = attrs[:speed]
       arry << new(provider_hash)
     end
   end
@@ -72,6 +73,7 @@ Puppet::Type.type(:eos_ethernet).provide(:eos) do
                             if resource[:flowcontrol_send]
     self.flowcontrol_receive = resource[:flowcontrol_receive] \
                                if resource[:flowcontrol_receive]
+    self.speed = resource[:speed] if resource[:speed]
   end
 
   def destroy
@@ -98,5 +100,10 @@ Puppet::Type.type(:eos_ethernet).provide(:eos) do
   def flowcontrol_receive=(val)
     node.api('interfaces').set_flowcontrol_receive(resource[:name], value: val)
     @property_hash[:flowcontrol_receive] = val
+  end
+
+  def speed=(val)
+    node.api('interfaces').set_speed(resource[:name], value: val)
+    @property_hash[:speed] = val
   end
 end

--- a/lib/puppet/provider/eos_ethernet/default.rb
+++ b/lib/puppet/provider/eos_ethernet/default.rb
@@ -60,6 +60,7 @@ Puppet::Type.type(:eos_ethernet).provide(:eos) do
       provider_hash[:flowcontrol_send] = attrs[:flowcontrol_send].to_sym
       provider_hash[:flowcontrol_receive] = attrs[:flowcontrol_receive].to_sym
       provider_hash[:speed] = attrs[:speed]
+      provider_hash[:lacp_priority] = attrs[:lacp_priority]
       arry << new(provider_hash)
     end
   end
@@ -74,6 +75,7 @@ Puppet::Type.type(:eos_ethernet).provide(:eos) do
     self.flowcontrol_receive = resource[:flowcontrol_receive] \
                                if resource[:flowcontrol_receive]
     self.speed = resource[:speed] if resource[:speed]
+    self.lacp_priority = resource[:lacp_priority] if resource[:lacp_priority]
   end
 
   def destroy
@@ -105,5 +107,10 @@ Puppet::Type.type(:eos_ethernet).provide(:eos) do
   def speed=(val)
     node.api('interfaces').set_speed(resource[:name], value: val)
     @property_hash[:speed] = val
+  end
+
+  def lacp_priority=(val)
+    node.api('interfaces').set_lacp_priority(resource[:name], value: val)
+    @property_hash[:lacp_priority] = val
   end
 end

--- a/lib/puppet/type/eos_ethernet.rb
+++ b/lib/puppet/type/eos_ethernet.rb
@@ -45,6 +45,7 @@ Puppet::Type.newtype(:eos_ethernet) do
           flowcontrol_send    => on,
           flowcontrol_receive => on,
           speed               => 'forced 40gfull',
+          lacp_priority       => 0,
         }
   EOS
 
@@ -136,5 +137,23 @@ Puppet::Type.newtype(:eos_ethernet) do
               'forced 1000full', 'forced 1000half', 'forced 100full',
               'forced 100gfull', 'forced 100half', 'forced 10full',
               'forced 10half', 'forced 40gfull', 'sfp-1000baset auto 100full')
+  end
+
+  newproperty(:lacp_priority) do
+    desc <<-EOS
+      The lacp_priority property specifies the lacp port priority associated
+      with the ethernet interface. The configured value must be an integer in
+      the range of 0 to 65535.
+
+      The default value for the lacp_priority setting is 32768
+    EOS
+
+    munge { |value| Integer(value) }
+
+    validate do |value|
+      unless value.to_i.between?(0, 65_535)
+        fail "value #{value.inspect} must be between 0 and 65535"
+      end
+    end
   end
 end

--- a/lib/puppet/type/eos_ethernet.rb
+++ b/lib/puppet/type/eos_ethernet.rb
@@ -113,6 +113,7 @@ Puppet::Type.newtype(:eos_ethernet) do
       This property configures the interface speed for the specified Ethernet
       interface. Valid values for speed are:
 
+      * 'default'
       * '100full'
       * '10full'
       * 'auto'
@@ -130,10 +131,10 @@ Puppet::Type.newtype(:eos_ethernet) do
       * 'forced 40gfull'
       * 'sfp-1000baset auto 100full'
     EOS
-    newvalues('100full', '10full', 'auto', 'auto 100full', 'auto 10full',
-              'auto 40gfull', 'forced 10000full', 'forced 1000full',
-              'forced 1000half', 'forced 100full', 'forced 100gfull',
-              'forced 100half', 'forced 10full', 'forced 10half',
-              'forced 40gfull', 'sfp-1000baset auto 100full')
+    newvalues('default', '100full', '10full', 'auto', 'auto 100full',
+              'auto 10full', 'auto 40gfull', 'forced 10000full',
+              'forced 1000full', 'forced 1000half', 'forced 100full',
+              'forced 100gfull', 'forced 100half', 'forced 10full',
+              'forced 10half', 'forced 40gfull', 'sfp-1000baset auto 100full')
   end
 end

--- a/lib/puppet/type/eos_ethernet.rb
+++ b/lib/puppet/type/eos_ethernet.rb
@@ -113,7 +113,6 @@ Puppet::Type.newtype(:eos_ethernet) do
       This property configures the interface speed for the specified Ethernet
       interface. Valid values for speed are:
 
-      * :default
       * '100full'
       * '10full'
       * 'auto'
@@ -131,11 +130,10 @@ Puppet::Type.newtype(:eos_ethernet) do
       * 'forced 40gfull'
       * 'sfp-1000baset auto 100full'
     EOS
-    newvalues(:default, '100full', '10full', 'auto', 'auto 100full',
-              'auto 10full', 'auto 40gfull', 'forced 10000full',
-              'forced 1000full', 'forced 1000half', 'forced 100full',
-              'forced 100gfull', 'forced 100half', 'forced 10full',
-              'forced 10half', 'forced 40gfull',
-              'sfp-1000baset auto 100full')
+    newvalues('100full', '10full', 'auto', 'auto 100full', 'auto 10full',
+              'auto 40gfull', 'forced 10000full', 'forced 1000full',
+              'forced 1000half', 'forced 100full', 'forced 100gfull',
+              'forced 100half', 'forced 10full', 'forced 10half',
+              'forced 40gfull', 'sfp-1000baset auto 100full')
   end
 end

--- a/lib/puppet/type/eos_ethernet.rb
+++ b/lib/puppet/type/eos_ethernet.rb
@@ -44,6 +44,7 @@ Puppet::Type.newtype(:eos_ethernet) do
           description         => 'To switch2 Ethernet 1/3',
           flowcontrol_send    => on,
           flowcontrol_receive => on,
+          speed               => 'forced 40gfull',
         }
   EOS
 
@@ -105,5 +106,36 @@ Puppet::Type.newtype(:eos_ethernet) do
       * off - Configures flowcontrol receive off
     EOS
     newvalues(:on, :off)
+  end
+
+  newproperty(:speed) do
+    desc <<-EOS
+      This property configures the interface speed for the specified Ethernet
+      interface. Valid values for speed are:
+
+      * :default
+      * '100full'
+      * '10full'
+      * 'auto'
+      * 'auto 100full'
+      * 'auto 10full'
+      * 'auto 40gfull'
+      * 'forced 10000full'
+      * 'forced 1000full'
+      * 'forced 1000half'
+      * 'forced 100full'
+      * 'forced 100gfull'
+      * 'forced 100half'
+      * 'forced 10full'
+      * 'forced 10half'
+      * 'forced 40gfull'
+      * 'sfp-1000baset auto 100full'
+    EOS
+    newvalues(:default, '100full', '10full', 'auto', 'auto 100full',
+              'auto 10full', 'auto 40gfull', 'forced 10000full',
+              'forced 1000full', 'forced 1000half', 'forced 100full',
+              'forced 100gfull', 'forced 100half', 'forced 10full',
+              'forced 10half', 'forced 40gfull',
+              'sfp-1000baset auto 100full')
   end
 end

--- a/spec/fixtures/ethernet.json
+++ b/spec/fixtures/ethernet.json
@@ -4,6 +4,7 @@
         "description": "test interface",
         "shutdown": false,
         "flowcontrol_send": "on",
-        "flowcontrol_receive": "on"
+        "flowcontrol_receive": "on",
+        "speed": "forced 40gfull"
     }
 }

--- a/spec/support/shared_examples_for_types.rb
+++ b/spec/support/shared_examples_for_types.rb
@@ -311,7 +311,11 @@ end
 RSpec.shared_examples 'speed property' do
   include_examples 'property'
 
-  %w(auto 1g 10g 40g 56g 100g 100m 10m).each do |val|
+  [:default, '100full', '10full', 'auto', 'auto 100full', 'auto 10full',
+    'auto 40gfull', 'forced 10000full', 'forced 1000full', 'forced 1000half',
+    'forced 100full', 'forced 100gfull', 'forced 100half', 'forced 10full',
+    'forced 10half', 'forced 40gfull',
+    'sfp-1000baset auto 100full'].each do |val|
     it "accepts #{val.inspect}" do
       type[attribute] = val
     end

--- a/spec/unit/puppet/provider/eos_ethernet/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_ethernet/default_spec.rb
@@ -43,6 +43,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
       flowcontrol_send: :on,
       flowcontrol_receive: :on,
       speed: 'forced 40gfull',
+      lacp_priority: 0,
       provider: described_class.name
     }
     Puppet::Type.type(:eos_ethernet).new(resource_hash)
@@ -91,7 +92,8 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
                          enable: :true,
                          flowcontrol_send: :on,
                          flowcontrol_receive: :on,
-                         speed: 'forced 40gfull'
+                         speed: 'forced 40gfull',
+                         lacp_priority: 0
       end
     end
 
@@ -113,6 +115,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
           expect(rsrc.provider.flowcontrol_send).to eq(:absent)
           expect(rsrc.provider.flowcontrol_receive).to eq(:absent)
           expect(rsrc.provider.speed).to eq(:absent)
+          expect(rsrc.provider.lacp_priority).to eq(:absent)
         end
       end
 
@@ -124,6 +127,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
         expect(resources['Ethernet1'].provider.flowcontrol_send).to eq(:on)
         expect(resources['Ethernet1'].provider.flowcontrol_receive).to eq(:on)
         expect(resources['Ethernet1'].provider.speed).to eq('forced 40gfull')
+        expect(resources['Ethernet1'].provider.lacp_priority).to eq(0)
       end
 
       it 'does not set the provider instance of the unmanaged resource' do
@@ -134,6 +138,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
         expect(resources['Ethernet2'].provider.flowcontrol_receive).to \
           eq(:absent)
         expect(resources['Ethernet2'].provider.speed).to eq(:absent)
+        expect(resources['Ethernet2'].provider.lacp_priority).to eq(:absent)
       end
     end
   end
@@ -149,7 +154,8 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
           set_description: true,
           set_flowcontrol_send: true,
           set_flowcontrol_receive: true,
-          set_speed: true
+          set_speed: true,
+          set_lacp_priority: true,
         )
       end
 
@@ -176,6 +182,11 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
       it 'sets speed on the resource' do
         provider.create
         expect(provider.speed).to eq(:'forced 40gfull')
+      end
+
+      it 'sets lacp priority on the resource' do
+        provider.create
+        expect(provider.lacp_priority).to eq(0)
       end
     end
 
@@ -239,6 +250,15 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
           .with(resource[:name], value: 'auto')
         provider.speed = 'auto'
         expect(provider.speed).to eq('auto')
+      end
+    end
+
+    describe '#lacp_priority=(value)' do
+      it 'updates lacp priority in the provider' do
+        expect(api).to receive(:set_lacp_priority)
+          .with(resource[:name], value: 65000)
+        provider.lacp_priority = 65000
+        expect(provider.lacp_priority).to eq(65000)
       end
     end
   end

--- a/spec/unit/puppet/provider/eos_ethernet/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_ethernet/default_spec.rb
@@ -42,6 +42,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
       enable: :true,
       flowcontrol_send: :on,
       flowcontrol_receive: :on,
+      speed: 'forced 40gfull',
       provider: described_class.name
     }
     Puppet::Type.type(:eos_ethernet).new(resource_hash)
@@ -89,7 +90,8 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
                          description: 'test interface',
                          enable: :true,
                          flowcontrol_send: :on,
-                         flowcontrol_receive: :on
+                         flowcontrol_receive: :on,
+                         speed: 'forced 40gfull'
       end
     end
 
@@ -110,6 +112,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
           expect(rsrc.provider.enable).to eq(:absent)
           expect(rsrc.provider.flowcontrol_send).to eq(:absent)
           expect(rsrc.provider.flowcontrol_receive).to eq(:absent)
+          expect(rsrc.provider.speed).to eq(:absent)
         end
       end
 
@@ -120,6 +123,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
         expect(resources['Ethernet1'].provider.enable).to eq :true
         expect(resources['Ethernet1'].provider.flowcontrol_send).to eq(:on)
         expect(resources['Ethernet1'].provider.flowcontrol_receive).to eq(:on)
+        expect(resources['Ethernet1'].provider.speed).to eq('forced 40gfull')
       end
 
       it 'does not set the provider instance of the unmanaged resource' do
@@ -129,6 +133,7 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
         expect(resources['Ethernet2'].provider.flowcontrol_send).to eq(:absent)
         expect(resources['Ethernet2'].provider.flowcontrol_receive).to \
           eq(:absent)
+        expect(resources['Ethernet2'].provider.speed).to eq(:absent)
       end
     end
   end
@@ -143,7 +148,8 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
           set_shutdown: true,
           set_description: true,
           set_flowcontrol_send: true,
-          set_flowcontrol_receive: true
+          set_flowcontrol_receive: true,
+          set_speed: true
         )
       end
 
@@ -165,6 +171,11 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
       it 'sets flowcontrol_receive on the resource' do
         provider.create
         expect(provider.flowcontrol_receive).to eq(:on)
+      end
+
+      it 'sets speed on the resource' do
+        provider.create
+        expect(provider.speed).to eq(:'forced 40gfull')
       end
     end
 
@@ -219,6 +230,15 @@ describe Puppet::Type.type(:eos_ethernet).provider(:eos) do
           provider.flowcontrol_receive = val
           expect(provider.flowcontrol_receive).to eq(val)
         end
+      end
+    end
+
+    describe '#speed=(value)' do
+      it 'updates speed in the provider' do
+        expect(api).to receive(:set_speed)
+          .with(resource[:name], value: 'auto')
+        provider.speed = 'auto'
+        expect(provider.speed).to eq('auto')
       end
     end
   end

--- a/spec/unit/puppet/provider/eos_ethernet/fixture_ethernet.yaml
+++ b/spec/unit/puppet/provider/eos_ethernet/fixture_ethernet.yaml
@@ -4,6 +4,7 @@ Ethernet1:
   :description: test interface
   :shutdown: false
   :flowcontrol_send: 'on'
-  :flowcontrol_receive: 'on' 
+  :flowcontrol_receive: 'on'
   :speed: forced 40gfull
+  :lacp_priority: 0
 

--- a/spec/unit/puppet/provider/eos_ethernet/fixture_ethernet.yaml
+++ b/spec/unit/puppet/provider/eos_ethernet/fixture_ethernet.yaml
@@ -5,4 +5,5 @@ Ethernet1:
   :shutdown: false
   :flowcontrol_send: 'on'
   :flowcontrol_receive: 'on' 
+  :speed: forced 40gfull
 

--- a/spec/unit/puppet/type/eos_ethernet_spec.rb
+++ b/spec/unit/puppet/type/eos_ethernet_spec.rb
@@ -84,4 +84,20 @@ describe Puppet::Type.type(:eos_ethernet) do
     include_examples 'accepts values', [:on, :off]
     include_examples 'rejected parameter values'
   end
+
+  describe 'speed' do
+    let(:attribute) { :speed }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'property'
+    include_examples '#doc Documentation'
+    include_examples 'accepts values without munging', [:default, :'100full',
+      :'10full', :'auto', :'auto 100full', :'auto 10full', :'auto 40gfull',
+      :'forced 10000full', :'forced 1000full', :'forced 1000half',
+      :'forced 100full', :'forced 100gfull', :'forced 100half',
+      :'forced 10full', :'forced 10half', :'forced 40gfull',
+      :'sfp-1000baset auto 100full']
+    include_examples 'rejects values', [0, 15, '0', '15', { two: :three },
+      :'abc']
+  end
 end

--- a/spec/unit/puppet/type/eos_ethernet_spec.rb
+++ b/spec/unit/puppet/type/eos_ethernet_spec.rb
@@ -99,4 +99,14 @@ describe Puppet::Type.type(:eos_ethernet) do
     include_examples 'rejects values', [0, 15, '0', '15', { two: :three },
       :'abc']
   end
+
+  describe 'lacp_priority' do
+    let(:attribute) { :lacp_priority }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'property'
+    include_examples '#doc Documentation'
+    include_examples 'accepts values without munging', [0, 65535]
+    include_examples 'rejects values', [[-1], -1, 65536, { two: :three }]
+  end
 end

--- a/spec/unit/puppet/type/eos_ethernet_spec.rb
+++ b/spec/unit/puppet/type/eos_ethernet_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:eos_ethernet) do
 
     include_examples 'property'
     include_examples '#doc Documentation'
-    include_examples 'accepts values', ['100full', '10full', 'auto',
+    include_examples 'accepts values', ['default', '100full', '10full', 'auto',
       'auto 100full', 'auto 10full', 'auto 40gfull', 'forced 10000full',
       'forced 1000full', 'forced 1000half', 'forced 100full',
       'forced 100gfull', 'forced 100half', 'forced 10full', 'forced 10half',

--- a/spec/unit/puppet/type/eos_ethernet_spec.rb
+++ b/spec/unit/puppet/type/eos_ethernet_spec.rb
@@ -91,12 +91,11 @@ describe Puppet::Type.type(:eos_ethernet) do
 
     include_examples 'property'
     include_examples '#doc Documentation'
-    include_examples 'accepts values without munging', [:default, :'100full',
-      :'10full', :'auto', :'auto 100full', :'auto 10full', :'auto 40gfull',
-      :'forced 10000full', :'forced 1000full', :'forced 1000half',
-      :'forced 100full', :'forced 100gfull', :'forced 100half',
-      :'forced 10full', :'forced 10half', :'forced 40gfull',
-      :'sfp-1000baset auto 100full']
+    include_examples 'accepts values', ['100full', '10full', 'auto',
+      'auto 100full', 'auto 10full', 'auto 40gfull', 'forced 10000full',
+      'forced 1000full', 'forced 1000half', 'forced 100full',
+      'forced 100gfull', 'forced 100half', 'forced 10full', 'forced 10half',
+      'forced 40gfull', 'sfp-1000baset auto 100full']
     include_examples 'rejects values', [0, 15, '0', '15', { two: :three },
       :'abc']
   end


### PR DESCRIPTION
* adds speed settings to the ethernet resource
* adds lacp port-priority settings to the ethernet resource
* This pull request depends on the following pull request: https://github.com/arista-eosplus/rbeapi/pull/138