### PR TITLE
add switchport trunk allowed vlan list capability

### DIFF
--- a/spec/support/shared_examples_for_types.rb
+++ b/spec/support/shared_examples_for_types.rb
@@ -184,7 +184,7 @@ RSpec.shared_examples 'vlan id value' do
 end
 
 RSpec.shared_examples 'vlan range value' do
-  [1, 10, 100, 4094].each do |val|
+  ['1', '10', '100', '2000-2099', '4094'].each do |val|
     it "munges #{val.inspect} to [#{val}]" do
       type[attribute] = val
       expect(type[attribute]).to eq([val])
@@ -311,7 +311,11 @@ end
 RSpec.shared_examples 'speed property' do
   include_examples 'property'
 
-  %w(auto 1g 10g 40g 56g 100g 100m 10m).each do |val|
+  [:default, '100full', '10full', 'auto', 'auto 100full', 'auto 10full',
+    'auto 40gfull', 'forced 10000full', 'forced 1000full', 'forced 1000half',
+    'forced 100full', 'forced 100gfull', 'forced 100half', 'forced 10full',
+    'forced 10half', 'forced 40gfull',
+    'sfp-1000baset auto 100full'].each do |val|
     it "accepts #{val.inspect}" do
       type[attribute] = val
     end

--- a/spec/unit/puppet/provider/eos_switchport/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_switchport/default_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
       ensure: :present,
       name: 'Ethernet1',
       mode: :trunk,
-      trunk_allowed_vlans: %w(1 10 100 1000),
+      trunk_allowed_vlans: ['1','10','100-500','1000'],
       trunk_native_vlan: '1',
       access_vlan: '1',
       trunk_groups: [],
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
                          ensure: :present,
                          name: 'Ethernet1',
                          mode: :trunk,
-                         trunk_allowed_vlans: [1, 10, 100, 1000],
+                         trunk_allowed_vlans: ['1', '10', '100-500', '1000'],
                          trunk_native_vlan: '1',
                          access_vlan: '1',
                          trunk_groups: []
@@ -128,7 +128,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
         expect(resources['Ethernet1'].provider.access_vlan).to eq '1'
         expect(resources['Ethernet1'].provider.trunk_native_vlan).to eq '1'
         expect(resources['Ethernet1'].provider.trunk_allowed_vlans).to \
-          eq [1, 10, 100, 1000]
+          eq ['1', '10', '100-500', '1000']
         expect(resources['Ethernet1'].provider.trunk_groups).to eq []
       end
 
@@ -239,7 +239,7 @@ describe Puppet::Type.type(:eos_switchport).provider(:eos) do
     end
 
     describe '#trunk_allowed_vlans=(val)' do
-      let(:vlans) { %w(1 10 100 1000) }
+      let(:vlans) { ['1','10','100-500','1000'] }
 
       it 'updates trunk_allowed_vlans in the provider' do
         expect(api).to receive(:set_trunk_allowed_vlans)

--- a/spec/unit/puppet/provider/eos_switchport/fixture_switchports.yaml
+++ b/spec/unit/puppet/provider/eos_switchport/fixture_switchports.yaml
@@ -3,6 +3,6 @@ Ethernet1:
   :mode: trunk
   :access_vlan: "1"
   :trunk_native_vlan: "1"
-  :trunk_allowed_vlans: [1,10,100,1000]
+  :trunk_allowed_vlans: ['1','10','100-500','1000']
   :trunk_groups: []
 


### PR DESCRIPTION
* Adds switchport allowed vlan range capability. Allowed vlans will be returned as they appear in the eos and can be configured in the same way as in the eos: (old: 5,6,7,9,10,15 new: 5-7,9-10,15)
* The allowed vlans array changed from int to string because a vlan range could be returned and set
* This pull request depends on https://github.com/arista-eosplus/rbeapi/pull/141