### PR TITLE
add mst instance type and provider

### DIFF
--- a/lib/puppet/provider/eos_mst_instance/default.rb
+++ b/lib/puppet/provider/eos_mst_instance/default.rb
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2014, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+require 'puppet/type'
+require 'pathname'
+
+module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
+require File.join module_lib, 'puppet_x/eos/provider'
+
+Puppet::Type.type(:eos_mst_instance).provide(:eos) do
+  desc 'Manage MST instance configuration on EOS.  Requires rbeapi rubygem.'
+  confine operatingsystem: [:AristaEOS] unless ENV['RBEAPI_CONNECTION']
+  confine feature: :rbeapi
+
+  # Create methods that set the @property_hash for the #flush method
+  mk_resource_methods
+
+  # Mix in the api as instance methods
+  include PuppetX::Eos::EapiProviderMixin
+
+  # Mix in the api as class methods
+  extend PuppetX::Eos::EapiProviderMixin
+
+  def self.instances
+    result = node.api('stp').get
+    return [] if !result || result.empty?
+    result[:instances].map do |(name, attrs)|
+      provider_hash = { :name => name, priority: attrs[:priority] }
+      if attrs[:priority] == ''
+        provider_hash[:ensure] = :absent
+      else
+        provider_hash[:ensure] = :present
+      end
+      new(provider_hash)
+    end
+  end
+
+  def initialize(resource = {})
+    super(resource)
+    @property_flush = {}
+  end
+
+  def priority=(val)
+    @property_flush[:priority] = val
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    fail('priority property must be included') if resource[:priority].nil?
+    @property_flush = resource.to_hash
+  end
+
+  def destroy
+    @property_flush = resource.to_hash
+  end
+
+  def flush
+    api = node.api('stp').instances
+    @property_hash.merge!(@property_flush)
+
+    case @property_hash[:ensure]
+    when :present
+      api.set_priority(resource[:name], value: @property_flush[:priority])
+    when :absent
+      api.set_priority(resource[:name], enable: false)
+    end
+    @property_flush = {}
+  end
+end

--- a/lib/puppet/type/eos_mst_instance.rb
+++ b/lib/puppet/type/eos_mst_instance.rb
@@ -1,0 +1,89 @@
+#
+# Copyright (c) 2014, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#  Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  Neither the name of Arista Networks nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# encoding: utf-8
+
+Puppet::Type.newtype(:eos_mst_instance) do
+  @doc = <<-EOS
+    Configure MST instance settings.
+
+    Example:
+
+        eos_mst_instance { '0':
+          priority => 8192,
+        }
+  EOS
+
+  ensurable
+
+  # Parameters
+
+  newparam(:name) do
+    @doc = <<-EOS
+      The name parameter specifies the MST instance identifier of the Arista
+      EOS MST instance identifier to manage. This value must correspond to a
+      valid MST instance identifier in EOS. It's value must be between
+      0 and 4094.
+    EOS
+
+    # Make sure we have a string for the ID
+    munge do |value|
+      Integer(value).to_s
+    end
+
+    validate do |value|
+      unless value.to_i.between?(0, 4_094)
+        fail "value #{value.inspect} is not between 0 and 4094"
+      end
+    end
+  end
+
+  # Properties (state management)
+
+  newproperty(:priority) do
+    @doc = <<-EOS
+      Specifies the MST bridge priority. The MST priority must have a value
+      between 0 and 61440 in increments of 4096.
+    EOS
+
+    # Make sure we have a string for the ID
+    munge do |value|
+      Integer(value).to_s
+    end
+
+    validate do |value|
+      unless value.to_i.between?(0, 61_440) && (value.to_i % 4096) == 0
+        fail "value #{value.inspect} is not between 0 and 65535"
+      end
+    end
+  end
+
+end

--- a/spec/fixtures/fixture_stp.yaml
+++ b/spec/fixtures/fixture_stp.yaml
@@ -1,5 +1,10 @@
 ---
 :mode: mstp
+:instances:
+  '0':
+      :priority: "8192"
+  '1':
+      :priority: ""
 :interfaces:
   Ethernet1:
     :portfast: true

--- a/spec/unit/puppet/provider/eos_mst_instance/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_mst_instance/default_spec.rb
@@ -1,0 +1,187 @@
+#
+# Copyright (c) 2014, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+require 'spec_helper'
+
+include FixtureHelpers
+
+describe Puppet::Type.type(:eos_mst_instance).provider(:eos) do
+  # Puppet RAL memoized methods
+  let(:resource) do
+    resource_hash = {
+      ensure: :present,
+      name: '0',
+      priority: '8192',
+      provider: described_class.name
+    }
+    Puppet::Type.type(:eos_mst_instance).new(resource_hash)
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:api) { double('stp') }
+  let(:instances) { double('stp.instances') }
+
+  def stp
+    stp = Fixtures[:stp]
+    return stp if stp
+    fixture('stp')
+  end
+
+  before :each do
+    allow(described_class.node).to receive(:api).with('stp')
+      .and_return(api)
+    allow(provider.node).to receive(:api).with('stp')
+      .and_return(api)
+    allow(api).to receive(:instances).and_return(instances)
+  end
+
+  context 'class methods' do
+    before { allow(api).to receive(:get).and_return(stp) }
+
+    describe '.instances' do
+      subject { described_class.instances }
+
+      it { is_expected.to be_an Array }
+
+      it 'has one entry' do
+        expect(subject.size).to eq(2)
+      end
+
+      it 'has an instance 0' do
+        instance = subject.find { |p| p.name == '0' }
+        expect(instance).to be_a described_class
+      end
+
+      context 'eos_mst_instance { 0 }' do
+        subject { described_class.instances.find { |p| p.name == '0' } }
+
+        include_examples 'provider resource methods',
+                         ensure: :present,
+                         name: '0',
+                         priority: '8192'
+      end
+
+      context 
+
+    end
+
+    describe '.prefetch' do
+      let :resources do
+        {
+          '0' => Puppet::Type.type(:eos_mst_instance).new(name: '0'),
+          '100' => Puppet::Type.type(:eos_mst_instance).new(name: '100')
+        }
+      end
+      subject { described_class.prefetch(resources) }
+
+      it 'resource providers are absent prior to calling .prefetch' do
+        resources.values.each do |rsrc|
+          expect(rsrc.provider.priority).to eq(:absent)
+        end
+      end
+
+      it 'sets the provider instance of the managed resource' do
+        subject
+        res = resources['0']
+        expect(res.provider.priority).to eq('8192')
+      end
+
+      it 'does not set the provider instance of the unmanaged resource' do
+        subject
+        res = resources['100']
+        expect(res.provider.priority).to eq(:absent)
+      end
+    end
+  end
+
+  context 'resource (instance) methods' do
+    describe '#exists?' do
+      subject { provider.exists? }
+
+      context 'when the resource does not exist on the system' do
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the resource exists on the system' do
+        let(:provider) do
+          allow(api).to receive(:get).and_return(stp)
+          described_class.instances.first
+        end
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    describe '#create' do
+      let(:name) { resource[:name] }
+
+      it 'sets ensure to :present' do
+        expect(instances).to receive(:set_priority).with('0', value: '16384')
+        provider.create
+        provider.priority = '16384'
+        provider.flush
+        expect(provider.ensure).to eq(:present)
+      end
+
+      context 'when priority is blank' do
+        it 'sets ensure to :present' do
+          resource[:ensure] = :present
+          resource.delete(:priority)
+          expect { provider.create }.to raise_error
+        end
+      end
+    end
+
+    describe '#destroy' do
+      let(:name) { resource[:name] }
+    
+      it 'sets ensure to :absent' do
+        expect(instances).to receive(:set_priority).with(name, enable: false)
+        resource[:ensure] = :absent
+        provider.destroy
+        provider.flush
+        expect(provider.ensure).to eq(:absent)
+      end
+    end
+
+    describe '#priority=(value)' do
+      let(:name) { resource[:name] }
+
+      it 'enables mst priority in the provider' do
+        expect(instances).to receive(:set_priority).with('0', value: '16384')
+        provider.create
+        provider.priority = '16384'
+        provider.flush
+        expect(provider.priority).to eq('16384')
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/eos_mst_instance_spec.rb
+++ b/spec/unit/puppet/type/eos_mst_instance_spec.rb
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2014, Arista Networks, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#  Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  Neither the name of Arista Networks nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:eos_mst_instance) do
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let(:type) { described_class.new(:name => '100', :catalog => catalog) }
+
+  # Cannot use the helper ensurable type check because even though the
+  # namevar is always a string, for this type the namevar is really an integer
+  # and the type will validate that the name can be converted to an integer.
+
+  describe 'name' do
+    let(:attribute) { :name }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'parameter'
+    include_examples '#doc Documentation'
+    include_examples 'accepts values without munging', %w(0 200 3278 4094)
+    include_examples 'rejects values', [4_095, 'string', { :two => :three }]
+  end
+
+  describe 'priority' do
+    let(:attribute) { :priority }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'property'
+    include_examples '#doc Documentation'
+    include_examples 'accepts values without munging', %w(0 20480 45056 61440)
+    include_examples 'rejects values', [100, 65_536, 'string', { :two => :three }]
+  end
+
+end


### PR DESCRIPTION
This adds the mst instance type and provider and the corresponding tests. For the code to work correctly with the rbeapi, the pull request https://github.com/arista-eosplus/rbeapi/pull/144 is required, there the parse_instances function is fixed.