### PR TITLE
modify munge not to rely on netaddr gem

### DIFF
--- a/lib/puppet/type/eos_varp.rb
+++ b/lib/puppet/type/eos_varp.rb
@@ -32,7 +32,6 @@
 
 # Work around due to autoloader issues: https://projects.puppetlabs.com/issues/4248
 require File.dirname(__FILE__) + '/../../puppet_x/eos/utils/helpers'
-require 'netaddr'
 
 Puppet::Type.newtype(:eos_varp) do
   @doc = <<-EOS
@@ -49,12 +48,10 @@ Puppet::Type.newtype(:eos_varp) do
   ensurable
 
   def munge_mac_address(value)
-    begin
-      addr = NetAddr::EUI.create(value)
-    rescue
+    value.scan(/\h/).length == 12 or
       raise "value #{value.inspect} is invalid, must be a mac address."
-    end
-    addr.address(Delimiter: ':')
+    value.gsub!(/\H/, '')
+    value.scan(/.{2}/).join(':')
   end
 
   # Parameters

--- a/spec/unit/puppet/type/eos_varp_spec.rb
+++ b/spec/unit/puppet/type/eos_varp_spec.rb
@@ -58,8 +58,12 @@ describe Puppet::Type.type(:eos_varp) do
                                                     'FF:FF:FF:FF:FF:FF',
                                                     'ff-ff-ff-ff-ff-ff',
                                                     'ffff.ffff.ffff',
-                                                    '00:00:11:11:22:22']
-    include_examples 'rejects values', [1, :true, 'ffff:ffff:ffff',
-                                        'random$tring']
+                                                    'ffff:ffff:ffff',
+                                                    '00:00:11:11:22:22',
+                                                    '0a:0a:1b:1b:2c:2c',
+                                                    'aabbccddeeff',
+                                                    '001122AABBCC']
+    include_examples 'rejects values', [1, :true, 'random$tring',
+                                        'aa:bb::dd:ee:ff']
   end
 end


### PR DESCRIPTION
here's one possible munge for `:mac_address`, performed without netaddr for #101 

It doesn't really care about the input format for the `:mac_address` value as long as exactly 6 octets (12 HEX chars) are there. The output format is always the same `aa:bb:cc:dd:ee:ff`.

However, netaddr functionality may be needed in the future development of new types/provider, in which case it does not make much sense to get rid of the gem dependency here.