### PR TITLE
added support for autostate

### DIFF
--- a/lib/puppet/provider/eos_interface/default.rb
+++ b/lib/puppet/provider/eos_interface/default.rb
@@ -66,6 +66,11 @@ Puppet::Type.type(:eos_interface).provide(:eos) do
     @property_hash[:enable] = val
   end
 
+  def autostate=(val)
+    node.api('interfaces').set_autostate(resource[:name], value: val)
+    @property_hash[:autostate] = val
+  end
+
   def description=(val)
     node.api('interfaces').set_description(resource[:name], value: val)
     @property_hash[:description] = val

--- a/lib/puppet/type/eos_interface.rb
+++ b/lib/puppet/type/eos_interface.rb
@@ -40,6 +40,7 @@ Puppet::Type.newtype(:eos_interface) do
         eos_interface { 'Management1':
           enable      => true,
           description => 'OOB management to mgmt-sw1 Ethernet42',
+          autostate   => true,
         }
   EOS
 
@@ -78,6 +79,17 @@ Puppet::Type.newtype(:eos_interface) do
 
       * true - Administratively enables the interface
       * false - Administratively disables the interface
+    EOS
+    newvalues(:true, :false)
+  end
+
+  newproperty(:autostate) do
+    desc <<-EOS
+      This option configures autostate on a VLAN interface.
+      Valid values for enable are:
+
+      * true - Enable autostate (default setting on EOS)
+      * false - Set no autostate
     EOS
     newvalues(:true, :false)
   end

--- a/spec/unit/puppet/provider/eos_interface/default_spec.rb
+++ b/spec/unit/puppet/provider/eos_interface/default_spec.rb
@@ -40,6 +40,7 @@ describe Puppet::Type.type(:eos_interface).provider(:eos) do
       name: 'Loopback0',
       description: 'test interface',
       enable: :true,
+      autostate: :true,
       provider: described_class.name
     }
     Puppet::Type.type(:eos_interface).new(resource_hash)

--- a/spec/unit/puppet/provider/eos_interface/fixture_interfaces.yaml
+++ b/spec/unit/puppet/provider/eos_interface/fixture_interfaces.yaml
@@ -2,4 +2,5 @@
 Loopback0:
   :description: test interface
   :shutdown: false
+  :autostate: true
 

--- a/spec/unit/puppet/type/eos_interface_spec.rb
+++ b/spec/unit/puppet/type/eos_interface_spec.rb
@@ -64,4 +64,14 @@ describe Puppet::Type.type(:eos_interface) do
     include_examples 'boolean value'
     include_examples 'rejected parameter values'
   end
+
+  describe 'autostate' do
+    let(:attribute) { :autostate }
+    subject { described_class.attrclass(attribute) }
+
+    include_examples 'property'
+    include_examples '#doc Documentation'
+    include_examples 'boolean value'
+    include_examples 'rejected parameter values'
+  end
 end


### PR DESCRIPTION
This patch implements the autostate function for vlans, which is necessary for e.g. MLAG configuration.