### PR TITLE
(CVE-2017-8418) Update rubocop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ else
   # rubocop:disable Bundler/DuplicatedGem
   gem 'json'
   group :development, :test do
-    gem 'rubocop', '>=0.35.1'
+    gem 'rubocop', '>= 0.49.0'
   end
   # rubocop:enable Bundler/DuplicatedGem
 end


### PR DESCRIPTION
Rubocop 0.48.1 and below did not use /tmp in a safe way. This only
impacts development and is not used in running systems. Older versions
are still used for only for older Ruby versions.