### PR TITLE
return 'true' if the match succeeds.

### DIFF
--- a/lib/puppet/provider/eos_config/default.rb
+++ b/lib/puppet/provider/eos_config/default.rb
@@ -85,7 +85,7 @@ Puppet::Type.type(:eos_config).provide(:eos) do
     cfg = get_config
     if !@resource[:regexp].nil?
       regexp = Regexp.new(@resource[:regexp])
-      return true if cfg.scan(regexp).empty?
+      return true if ! cfg.scan(regexp).empty?
     end
     unless value.nil?
       exists = true unless cfg.scan(value).empty?


### PR DESCRIPTION

The check for the regex being found wasn't succeeding (if the regex match scan is NOT empty then return TRUE).

side note - the unit test for eos_config wasn't checking for a regex match succeed. I'm not sure how to fix that thou.