### PR TITLE
eos_routemap failed when the route map was empty.

### DIFF
--- a/lib/puppet/type/eos_routemap.rb
+++ b/lib/puppet/type/eos_routemap.rb
@@ -122,6 +122,7 @@ Puppet::Type.newtype(:eos_routemap) do
 
     # Sort the arrays before comparing
     def insync?(current)
+      return false if current == :absent
       current.sort == should.sort
     end
 
@@ -139,6 +140,7 @@ Puppet::Type.newtype(:eos_routemap) do
 
     # Sort the arrays before comparing
     def insync?(current)
+      return false if current == :absent
       current.sort == should.sort
     end
 


### PR DESCRIPTION
It's legal to have a route map defined:

    route-map MYROUTEMAP permit 10

    route-map MYOTHERROUTEMAP permit 10

without any entries. The eos_routemap  insync? functions were being invoked with current = :absent  (which is not an array). This patch checks for this symbol and returns false (as in no match) if found.