### PR TITLE
Eos prefixlist fix

### DIFF
--- a/lib/puppet/provider/eos_prefixlist/default.rb
+++ b/lib/puppet/provider/eos_prefixlist/default.rb
@@ -140,9 +140,15 @@ Puppet::Type.type(:eos_prefixlist).provide(:eos) do
     validate_identity(desired_state)
     case desired_state[:ensure]
     when :present
-      api.add_rule(name, action, prefix, seqno)
+      if !  api.add_rule(name, action, prefix, seqno) then
+        msg = "malformed entry 'ip prefix-list #{name} #{seqno} #{action} #{prefix}'"
+        raise ArgumentError, msg
+      end
     when :absent
-      api.delete(name, seqno)
+      if ! api.delete(name, seqno) then
+        msg = "deleting '#{name}' with sequence #{seqno}"
+        raise ArgumentError, msg
+      end
     end
     @property_hash = desired_state
   end

--- a/lib/puppet/type/eos_routemap.rb
+++ b/lib/puppet/type/eos_routemap.rb
@@ -122,6 +122,7 @@ Puppet::Type.newtype(:eos_routemap) do
 
     # Sort the arrays before comparing
     def insync?(current)
+      return false if current == :absent
       current.sort == should.sort
     end
 
@@ -139,6 +140,7 @@ Puppet::Type.newtype(:eos_routemap) do
 
     # Sort the arrays before comparing
     def insync?(current)
+      return false if current == :absent
       current.sort == should.sort
     end
 


### PR DESCRIPTION
It's legal to have a route map defined:

    route-map MYROUTEMAP permit 10

    route-map MYOTHERROUTEMAP permit 10

without any entries. The eos_routemap insync? functions were being invoked with current = :absent (which is not an array). This patch checks for this symbol and returns false (as in no match) if found.

And, RBEAPI errors from "eos_prefixlist" were being silently ignored. This fixes that.
